### PR TITLE
Nit Comment and Else Spacing

### DIFF
--- a/contracts/TimeLockedController.sol
+++ b/contracts/TimeLockedController.sol
@@ -75,7 +75,7 @@ contract TimeLockedController is HasRegistry, HasNoEther, HasNoTokens, Claimable
     string constant public IS_MINT_APPROVER = "isTUSDMintApprover";
 
     modifier onlyFastPauseOrOwner() {
-        require(msg.sender == trueUsdFastPause || msg.sender == owner, "must be mintKey or owner");
+        require(msg.sender == trueUsdFastPause || msg.sender == owner, "must be pauser or owner");
         _;
     }
 
@@ -204,7 +204,7 @@ contract TimeLockedController is HasRegistry, HasNoEther, HasNoTokens, Claimable
             dateTime.getDay(currentTimeZoneTime) == dateTime.getDay(timeOfLastMint)) {
             mintedToday = mintedToday.add(_value);
             require(mintedToday <= dailyMintLimit, "over the mint limit");
-        }else {
+        } else {
             mintedToday = _value;
         }
         timeOfLastMint = currentTimeZoneTime;
@@ -254,7 +254,7 @@ contract TimeLockedController is HasRegistry, HasNoEther, HasNoTokens, Claimable
             if (numberOfApproval < minSmallMintApproval) {
                 return false;
             }
-        }else {
+        } else {
             if (numberOfApproval < minLargeMintApproval) {
                 return false;
             }

--- a/contracts/mocks/DateTimeMock.sol
+++ b/contracts/mocks/DateTimeMock.sol
@@ -45,9 +45,9 @@ contract DateTimeMock {
         function getDaysInMonth(uint8 month, uint16 year) public pure returns (uint8) {
                 if (month == 1 || month == 3 || month == 5 || month == 7 || month == 8 || month == 10 || month == 12) {
                         return 31;
-                }else if (month == 4 || month == 6 || month == 9 || month == 11) {
+                } else if (month == 4 || month == 6 || month == 9 || month == 11) {
                         return 30;
-                }else if (isLeapYear(year)) {
+                } else if (isLeapYear(year)) {
                         return 29;
                 } else {
                         return 28;
@@ -165,7 +165,7 @@ contract DateTimeMock {
                 for (i = ORIGIN_YEAR; i < year; i++) {
                         if (isLeapYear(i)) {
                                 timestamp += LEAP_YEAR_IN_SECONDS;
-                        }else {
+                        } else {
                                 timestamp += YEAR_IN_SECONDS;
                         }
                 }


### PR DESCRIPTION

#### Changes
This corrects a revert note if the sender is not the fast minter.
This also standardizes the else whitespace.
Reviewers @terryli0095