### PR TITLE
Update Submodule Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ call delegateToNewContract(\_newContractAddress, \_balanceSheetAddress, \_allowa
 
 ## Testing
 
-Ensure the registry submodule is in the root directory
+Initialize the registry submodule in the root directory:
 
--`rm -r registry` -`git clone git@github.com:trusttoken/registry.git`
+- `git submodule init && git submodule update``
 
 To run the tests and generate a code coverage report:
 


### PR DESCRIPTION
#### Changes
This modifies the README to instruct users to use the `git submodule` commands instead of manually cloning. The initialized submodule is still a valid clone as before.

Reviewers @terryli0095 