### PR TITLE
Remember the Weekday

### DIFF
--- a/contracts/TimeLockedController.sol
+++ b/contracts/TimeLockedController.sol
@@ -115,9 +115,10 @@ contract TimeLockedController is HasRegistry, HasNoEther, HasNoTokens, Claimable
     //mint operations by the mintkey cannot be processed on defined holidays
     modifier notOnHoliday() {
         if (msg.sender != owner) {
-            uint16 year = dateTime.getYear(now.sub(timeZoneDiff));
-            uint8 month = dateTime.getMonth(now.sub(timeZoneDiff));
-            uint8 day = dateTime.getDay(now.sub(timeZoneDiff));
+            uint shiftedTimestamp = now.sub(timeZoneDiff);
+            uint16 year = dateTime.getYear(shiftedTimestamp);
+            uint8 month = dateTime.getMonth(shiftedTimestamp);
+            uint8 day = dateTime.getDay(shiftedTimestamp);
             require(!holidays[keccak256(year, month, day)], "not on holiday");
         }
         _;

--- a/contracts/TimeLockedController.sol
+++ b/contracts/TimeLockedController.sol
@@ -105,8 +105,9 @@ contract TimeLockedController is HasRegistry, HasNoEther, HasNoTokens, Claimable
     //mint operations by the mintkey cannot be processed on weekend
     modifier notOnWeekend() {
         if (msg.sender != owner) {
-            require(dateTime.getWeekday(now.sub(timeZoneDiff)) != 0, "cannot mint on weekend");
-            require(dateTime.getWeekday(now.sub(timeZoneDiff)) != 6, "cannot mint on weekend");
+            uint8 weekday = dateTime.getWeekday(now.sub(timeZoneDiff));
+            require(weekday != 0, "cannot mint on weekend");
+            require(weekday != 6, "cannot mint on weekend");
         }
         _;
     }


### PR DESCRIPTION

#### Changes
This trims an unnecessary call to getWeekday by keeping the result on the stack.
The compiler might already optimize this because `getWeekday` is a pure function.
Reviewers @terryli0095