### PR TITLE
add npm 'test' script to run coverage tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Initialize the registry submodule in the root directory:
 To run the tests and generate a code coverage report:
 
 - `npm install`
-- `./node_modules/.bin/solidity-coverage`
+- `npm test`
 
 ## Other Information
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/.bin/solidity-coverage"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
I think this is a somewhat cleaner way to approach this test script.