### PR TITLE
Restrict decimals to pure

### DIFF
--- a/contracts/TrueUSD.sol
+++ b/contracts/TrueUSD.sol
@@ -30,11 +30,11 @@ GasRefundToken {
 
     event ChangeTokenName(string newName, string newSymbol);
 
-    function decimals() public returns (uint8) {
+    function decimals() public view returns (uint8) {
       return DECIMALS;
     }
 
-    function rounding() public returns (uint8) {
+    function rounding() public view returns (uint8) {
       return ROUNDING;
     }
 

--- a/contracts/TrueUSD.sol
+++ b/contracts/TrueUSD.sol
@@ -30,11 +30,11 @@ GasRefundToken {
 
     event ChangeTokenName(string newName, string newSymbol);
 
-    function decimals() public view returns (uint8) {
+    function decimals() public pure returns (uint8) {
       return DECIMALS;
     }
 
-    function rounding() public view returns (uint8) {
+    function rounding() public pure returns (uint8) {
       return ROUNDING;
     }
 


### PR DESCRIPTION

#### Changes
This reduces the visibility of `decimals` and `rounding` to pure.
Reviewers @terryli0095