### PR TITLE
Paused Helper

### DIFF
--- a/contracts/TrueUSD.sol
+++ b/contracts/TrueUSD.sol
@@ -56,6 +56,10 @@ GasRefundToken {
         token.transfer(_to, balance);
     }
 
+    function paused() public pure returns (bool) {
+        return false;
+    }
+
     /**  
     *@dev allows owner of TrueUSD to gain ownership of any contract that TrueUSD currently owns
     */

--- a/contracts/utilities/PausedTrueUSD.sol
+++ b/contracts/utilities/PausedTrueUSD.sol
@@ -60,6 +60,9 @@ contract PausedToken is HasOwner {
     function decreaseApproval(address _spender, uint _subtractedValue) public returns (bool) {
         revert("Token Paused");
     }
+    function paused() public pure returns (bool) {
+        return true;
+    }
 }
 
 /** @title PausedDelegateERC20

--- a/test/PausedTrueUSD.test.js
+++ b/test/PausedTrueUSD.test.js
@@ -61,10 +61,11 @@ contract('PausedTrueUSD', function (accounts) {
         })
 
         it('current token is not paused', async function(){
+            assert.equal(await this.token.paused(), false);
             await this.token.transfer(otherAddress, 10*10**18, { from: oneHundred })
         })
 
-        it('current token is not paused', async function(){
+        it ('unpaused token can burn', async function() {
             await this.token.burn(10000*10**18, { from: oneHundred })
         })
 
@@ -77,6 +78,7 @@ contract('PausedTrueUSD', function (accounts) {
 
             describe('token transfers are now paused', function(){
                 it ('transfer is now paused', async function(){
+                    assert.equal(await this.token.paused(), true);
                     await assertRevert(this.token.transfer(otherAddress, 10*10**18, { from: oneHundred }))
                     await assertRevert(this.original.transfer(otherAddress, 10*10**18, { from: oneHundred }))
                 })


### PR DESCRIPTION

#### Changes
When we changed paused to paused_Deprecated, we lost the ability to monitor whether the current implementation was paused.
This restores that functionality with a paused helper.
Reviewers @terryli0095