### PR TITLE
Minimum gasPrice for Refund

### DIFF
--- a/contracts/GasRefundToken.sol
+++ b/contracts/GasRefundToken.sol
@@ -12,17 +12,27 @@ contract GasRefundToken is ModularMintableToken {
 
     function sponsorGas() external {
         uint256 len = gasRefundPool.length;
+        uint256 refundPrice = minimumGasPriceForFutureRefunds;
+        require(refundPrice > 0);
         gasRefundPool.length = len + 9;
         gasRefundPool[len] = 1;
-        gasRefundPool[len + 1] = 1;
-        gasRefundPool[len + 2] = 1;
-        gasRefundPool[len + 3] = 1;
-        gasRefundPool[len + 4] = 1;
-        gasRefundPool[len + 5] = 1;
-        gasRefundPool[len + 6] = 1;
-        gasRefundPool[len + 7] = 1;
-        gasRefundPool[len + 8] = 1;
-    }  
+        gasRefundPool[len + 1] = refundPrice;
+        gasRefundPool[len + 2] = refundPrice;
+        gasRefundPool[len + 3] = refundPrice;
+        gasRefundPool[len + 4] = refundPrice;
+        gasRefundPool[len + 5] = refundPrice;
+        gasRefundPool[len + 6] = refundPrice;
+        gasRefundPool[len + 7] = refundPrice;
+        gasRefundPool[len + 8] = refundPrice;
+    }
+
+    function minimumGasPriceForRefund() public view returns (uint256) {
+        uint256 len = gasRefundPool.length;
+        if (len > 0) {
+          return gasRefundPool[len - 1] + 1;
+        }
+        return uint256(-1);
+    }
 
     /**  
     @dev refund up to 45,000 (57,000 after Constantinople) gas for functions with 
@@ -30,7 +40,7 @@ contract GasRefundToken is ModularMintableToken {
     */
     modifier gasRefund {
         uint256 len = gasRefundPool.length;
-        if (len != 0) {
+        if (len != 0 && tx.gasprice > gasRefundPool[len-1]) {
             gasRefundPool[--len] = 0;
             gasRefundPool[--len] = 0;
             gasRefundPool[--len] = 0;
@@ -56,5 +66,12 @@ contract GasRefundToken is ModularMintableToken {
 
     function mint(address _to, uint256 _value) public onlyOwner gasRefund {
         super.mint(_to, _value);
+    }
+
+    bytes32 public constant CAN_SET_FUTURE_REFUND_MIN_GAS_PRICE = "canSetFutureRefundMinGasPrice";
+
+    function setMinimumGasPriceForFutureRefunds(uint256 _minimumGasPriceForFutureRefunds) public {
+        require(registry.hasAttribute(msg.sender, CAN_SET_FUTURE_REFUND_MIN_GAS_PRICE));
+        minimumGasPriceForFutureRefunds = _minimumGasPriceForFutureRefunds;
     }
 }

--- a/contracts/ProxyStorage.sol
+++ b/contracts/ProxyStorage.sol
@@ -32,4 +32,5 @@ contract ProxyStorage {
 
     uint[] public gasRefundPool;
     uint256 public redemptionAddressCount;
+    uint256 public minimumGasPriceForFutureRefunds;
 }

--- a/test/GasRefundToken.test.js
+++ b/test/GasRefundToken.test.js
@@ -26,25 +26,36 @@ contract('GasRefundToken', function (accounts) {
             await this.registry.setAttribute(oneHundred, "hasPassedKYC/AML", 1, notes, { from: owner })
             await this.token.mint(oneHundred, 100*10**18, { from: owner })
             await this.registry.setAttribute(oneHundred, "hasPassedKYC/AML", 0, notes, { from: owner })
+            await this.registry.setAttributeValue(oneHundred, "canSetFutureRefundMinGasPrice", 1, { from: owner });
         })
 
-        it('transfer to anotherAccount without gas refund', async function(){
+        it('blocks others from setting the minimum refund gas price', async function() {
+            await assertRevert(this.token.setMinimumGasPriceForFutureRefunds(1), { from: anotherAccount });
+        })
+
+        it('transfer to anotherAccount without gas refund', async function() {
             const receipt = await this.token.transfer(anotherAccount, 50*10**18, {from: oneHundred})
             await assertBalance(this.token,anotherAccount, 50*10**18)
+            await this.token.setMinimumGasPriceForFutureRefunds(1e3, { from: oneHundred });
+            await this.token.sponsorGas();
+            assert.equal(await this.token.remainingGasRefundPool(), 9);
+            await this.token.transfer(oneHundred, 50*10**18, { from: anotherAccount, gasPrice: 1000 });
+            assert.equal(await this.token.remainingGasRefundPool(), 9);
         })
 
 
         it('transfer to anotherAccount with gas refund', async function(){
             const FIFTY = 50*10**18;
+            await this.token.setMinimumGasPriceForFutureRefunds(1e3, { from: oneHundred });
             await this.token.sponsorGas({from: anotherAccount})
             await this.token.sponsorGas({from: anotherAccount})
             assert.equal(Number(await this.token.remainingGasRefundPool.call()),18)
             //truffle has no gas refund so this receipt of gas used is not accurate
-            const receipt = await this.token.transfer(anotherAccount, FIFTY, {from: oneHundred})
+            const receipt = await this.token.transfer(anotherAccount, FIFTY, {from: oneHundred, gasPrice: 1001, gasLimit: 150000})
             assert.equal(Number(await this.token.remainingGasRefundPool.call()),15)
             await assertBalance(this.token,anotherAccount, FIFTY)
             await this.token.approve(oneHundred, FIFTY, { from: anotherAccount });
-            await this.token.transferFrom(anotherAccount, oneHundred, FIFTY, { from: oneHundred });
+            await this.token.transferFrom(anotherAccount, oneHundred, FIFTY, { from: oneHundred, gasPrice: 1001, gasLimit: 200000 });
             assert.equal(Number(await this.token.remainingGasRefundPool.call()), 12);
         })
     })


### PR DESCRIPTION

#### Changes
This modifies our refund strategy so that we only refund transactions above a certain gasPrice.
This increases the cost of draining our refund pool.
Reviewers @terryli0095