### PR TITLE
0x100000 Redemption Addresses

### DIFF
--- a/contracts/Admin/TokenController.sol
+++ b/contracts/Admin/TokenController.sol
@@ -458,13 +458,6 @@ contract TokenController {
 
 
     /** 
-    *@dev Increment redemption address count of TrueUSD
-    */
-    function incrementRedemptionAddressCount() external onlyOwnerOrRedemptionAdmin {
-        trueUSD.incrementRedemptionAddressCount();
-    }
-
-    /** 
     *@dev Update this contract's trueUSD pointer to newContract (e.g. if the
     contract is upgraded)
     */

--- a/contracts/ProxyStorage.sol
+++ b/contracts/ProxyStorage.sol
@@ -31,5 +31,5 @@ contract ProxyStorage {
     string public symbol = "TUSD";
 
     uint[] public gasRefundPool;
-    uint256 public redemptionAddressCount_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
 }

--- a/contracts/ProxyStorage.sol
+++ b/contracts/ProxyStorage.sol
@@ -31,5 +31,5 @@ contract ProxyStorage {
     string public symbol = "TUSD";
 
     uint[] public gasRefundPool;
-    uint256 public redemptionAddressCount;
+    uint256 public redemptionAddressCount_Deprecated;
 }

--- a/contracts/RedeemableToken.sol
+++ b/contracts/RedeemableToken.sol
@@ -10,10 +10,12 @@ contract RedeemableToken is ModularMintableToken {
 
     event RedemptionAddress(address indexed addr);
 
+    uint256 public constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
     function _transferAllArgs(address _from, address _to, uint256 _value) internal {
         if (_to == address(0)) {
             revert("_to address is 0x0");
-        } else if (uint(_to) <= redemptionAddressCount) {
+        } else if (uint(_to) <= REDEMPTION_ADDRESS_COUNT) {
             // Transfers to redemption addresses becomes burn
             super._transferAllArgs(_from, _to, _value);
             _burnAllArgs(_to, _value);
@@ -25,17 +27,12 @@ contract RedeemableToken is ModularMintableToken {
     function _transferFromAllArgs(address _from, address _to, uint256 _value, address _sender) internal {
         if (_to == address(0)) {
             revert("_to address is 0x0");
-        } else if (uint(_to) <= redemptionAddressCount) {
+        } else if (uint(_to) <= REDEMPTION_ADDRESS_COUNT) {
             // Transfers to redemption addresses becomes burn
             super._transferFromAllArgs(_from, _to, _value, _sender);
             _burnAllArgs(_to, _value);
         } else {
             super._transferFromAllArgs(_from, _to, _value, _sender);
         }
-    }
-
-    function incrementRedemptionAddressCount() external onlyOwner {
-        emit RedemptionAddress(address(redemptionAddressCount));
-        redemptionAddressCount += 1;
     }
 }

--- a/contracts/utilities/PausedTrueUSD.sol
+++ b/contracts/utilities/PausedTrueUSD.sol
@@ -148,11 +148,6 @@ contract PausedTrueUSD is PausedDelegateERC20 {
         emit SetRegistry(registry);
     }
 
-    function incrementRedemptionAddressCount() external onlyOwner {
-        emit RedemptionAddress(address(redemptionAddressCount));
-        redemptionAddressCount += 1;
-    }
-
     function sponsorGas() external {
         uint256 len = gasRefundPool.length;
         gasRefundPool.length = len + 9;

--- a/test/PausedTrueUSD.test.js
+++ b/test/PausedTrueUSD.test.js
@@ -144,8 +144,6 @@ contract('PausedTrueUSD', function (accounts) {
                     assert.equal(Number(await this.token.remainingGasRefundPool.call()),9)
                     await this.controller.setTusdRegistry('0x0000000000000000000000000000000000000003',{from: owner})
                     assert.equal(await this.token.registry.call(), '0x0000000000000000000000000000000000000003')
-                    await this.controller.incrementRedemptionAddressCount({from: owner})
-                    assert.equal(await this.token.redemptionAddressCount.call(), 1)
                     await this.controller.changeTokenName("TerryToken","TTT", {from: owner})
                 })
 

--- a/test/RedeemToken.test.js
+++ b/test/RedeemToken.test.js
@@ -49,15 +49,9 @@ contract('RedeemToken', function (accounts) {
             const ADDRESS_ONE = '0x0000000000000000000000000000000000000001'
             const ADDRESS_TWO = '0x0000000000000000000000000000000000000002'
 
-            it('owner can increment Redemption address count', async function(){
-                await this.token.incrementRedemptionAddressCount({ from: owner })
-                assert.equal(Number(await this.token.redemptionAddressCount.call()),1)
-            })
-
             it('transfers to Redemption addresses gets burned', async function(){
                 await this.registry.setAttribute(ADDRESS_ONE, "canBurn", 1, notes, { from: owner })
                 await this.registry.setAttribute(ADDRESS_TWO, "canBurn", 1, notes, { from: owner })
-                await this.token.incrementRedemptionAddressCount({ from: owner })
                 const {logs} = await this.token.transfer(ADDRESS_ONE, 10*10**18, {from : oneHundred})
                 assert.equal(logs[0].event, 'Transfer')
                 assert.equal(logs[1].event, 'Burn')
@@ -66,13 +60,11 @@ contract('RedeemToken', function (accounts) {
                 assert.equal(Number(await this.token.totalSupply.call()),90*10**18)
                 await this.token.transfer(ADDRESS_TWO, 10*10**18, {from : oneHundred})
                 assert.equal(Number(await this.token.totalSupply.call()),90*10**18)
-                await this.token.incrementRedemptionAddressCount({ from: owner })
                 await this.token.transfer(ADDRESS_ONE, 10*10**18, {from : oneHundred})
                 assert.equal(Number(await this.token.totalSupply.call()),80*10**18)
             })
 
             it('transfers to Redemption addresses fails if Redemption address cannot burn', async function(){
-                await this.token.incrementRedemptionAddressCount({ from: owner })
                 await assertRevert(this.token.transfer(ADDRESS_ONE, 10*10**18, {from : oneHundred}))
             })
         })

--- a/test/RedeemToken.test.js
+++ b/test/RedeemToken.test.js
@@ -58,10 +58,12 @@ contract('RedeemToken', function (accounts) {
                 assert.equal(logs[2].event, 'Transfer')
                 await assertBalance(this.token, oneHundred, 90*10**18)
                 assert.equal(Number(await this.token.totalSupply.call()),90*10**18)
-                await this.token.transfer(ADDRESS_TWO, 10*10**18, {from : oneHundred})
+                await assertRevert(this.token.transfer('0x0000000000000000000000000000000000000004', 10*10**18, {from: oneHundred}))
                 assert.equal(Number(await this.token.totalSupply.call()),90*10**18)
-                await this.token.transfer(ADDRESS_ONE, 10*10**18, {from : oneHundred})
+                await this.token.transfer(ADDRESS_TWO, 10*10**18, {from : oneHundred})
                 assert.equal(Number(await this.token.totalSupply.call()),80*10**18)
+                await this.token.transfer(ADDRESS_ONE, 10*10**18, {from : oneHundred})
+                assert.equal(Number(await this.token.totalSupply.call()),70*10**18)
             })
 
             it('transfers to Redemption addresses fails if Redemption address cannot burn', async function(){

--- a/test/TokenController.test.js
+++ b/test/TokenController.test.js
@@ -515,20 +515,6 @@ contract('TokenController', function (accounts) {
             })
         })
 
-        describe('redemption addresses', function (){
-            it('owner and redemption Admin can increment Redemption Address Count', async function(){
-                await this.registry.setAttribute(redemptionAdmin, "isTUSDRedemptionAdmin", 1, "notes", { from: owner })
-                await this.controller.incrementRedemptionAddressCount({from: owner})
-                await this.controller.incrementRedemptionAddressCount({from: redemptionAdmin})
-                const redemptionAddressCount = Number(await this.token.redemptionAddressCount.call())
-                assert.equal(redemptionAddressCount,2)
-            })
-            it('other addresses cannot increment Redemption Address Count', async function(){
-                await assertRevert(this.controller.incrementRedemptionAddressCount({from: oneHundred}))
-            })
-        })
-
-
         describe('pause trueUSD and wipe accounts', function(){
             beforeEach(async function(){
                 this.fastPauseTrueUSD = await FastPauseTrueUSD.new(pauseKey, this.controller.address, { from: owner })


### PR DESCRIPTION

#### Changes
This allocates many redemption addresses for us to use instead of having us increment a counter one at a time.
Which ones are active is maintained by the registry.
We can modify the constant by upgrading if we need more.
Reviewers @terryli0095