### PR TITLE
GT 2

### DIFF
--- a/contracts/GasRefundToken.sol
+++ b/contracts/GasRefundToken.sol
@@ -39,7 +39,7 @@ contract GasRefundToken is ModularMintableToken {
     */
     modifier gasRefund {
         uint256 len = gasRefundPool.length;
-        if (len != 0 && tx.gasprice > gasRefundPool[len-1]) {
+        if (len > 2 && tx.gasprice > gasRefundPool[len-1]) {
             gasRefundPool[--len] = 0;
             gasRefundPool[--len] = 0;
             gasRefundPool[--len] = 0;


### PR DESCRIPTION

#### Changes
Instead of checking NOT EQ 0 we will check GT 2, which is marginally cheaper.
This should behave the same otherwise.
A one-sided check is also safer for unexpected negative lengths.
Reviewers @terryli0095