### PR TITLE
Remove duplicate SSTORES

### DIFF
--- a/contracts/GasRefundToken.sol
+++ b/contracts/GasRefundToken.sol
@@ -40,11 +40,8 @@ contract GasRefundToken is ModularMintableToken {
     modifier gasRefund {
         uint256 len = gasRefundPool.length;
         if (len > 2 && tx.gasprice > gasRefundPool[len-1]) {
-            gasRefundPool[--len] = 0;
-            gasRefundPool[--len] = 0;
-            gasRefundPool[--len] = 0;
-            gasRefundPool.length = len;
-        }   
+            gasRefundPool.length = len - 3;
+        }
         _;
     }
 

--- a/flat_contracts/flat_TokenController.sol
+++ b/flat_contracts/flat_TokenController.sol
@@ -980,11 +980,8 @@ contract GasRefundToken is ModularMintableToken {
     modifier gasRefund {
         uint256 len = gasRefundPool.length;
         if (len > 2 && tx.gasprice > gasRefundPool[len-1]) {
-            gasRefundPool[--len] = 0;
-            gasRefundPool[--len] = 0;
-            gasRefundPool[--len] = 0;
-            gasRefundPool.length = len;
-        }   
+            gasRefundPool.length = len - 3;
+        }
         _;
     }
 

--- a/flat_contracts/flat_tusd.sol
+++ b/flat_contracts/flat_tusd.sol
@@ -980,11 +980,8 @@ contract GasRefundToken is ModularMintableToken {
     modifier gasRefund {
         uint256 len = gasRefundPool.length;
         if (len > 2 && tx.gasprice > gasRefundPool[len-1]) {
-            gasRefundPool[--len] = 0;
-            gasRefundPool[--len] = 0;
-            gasRefundPool[--len] = 0;
-            gasRefundPool.length = len;
-        }   
+            gasRefundPool.length = len - 3;
+        }
         _;
     }
 


### PR DESCRIPTION

#### Changes
Thanks @terryli0095 for finding a way to do this without assembly.
Turns out solidity already zeroes array members when you subtract length.
Therefore we do not need to set zeroes beforehand.
Reviewers @terryli0095